### PR TITLE
Expose codegen as a library

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -494,12 +494,8 @@ async function makeAndWriteFiles(
 }
 
 function getWeb3xPath() {
-  try {
-    const pkg = JSON.parse(fs.readFileSync('package.json').toString());
-    return !!pkg.dependencies['web3x-es'] || !!pkg.devDependencies['web3x-es'] ? 'web3x-es' : 'web3x';
-  } catch (err) {
-    return 'web3x';
-  }
+  const pkg = JSON.parse(fs.readFileSync(__dirname + '/../../package.json').toString());
+  return pkg.name;
 }
 
 async function main() {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -476,7 +476,7 @@ async function makeAndWriteAbi(outputPath: string, name: string, abi: ContractAb
   */
 }
 
-async function makeAndWriteFiles(
+export async function makeAndWriteFiles(
   outputPath: string,
   name: string,
   abiLocation: string | ContractAbi,
@@ -493,7 +493,7 @@ async function makeAndWriteFiles(
   makeAndWriteAbi(outputPath, name, abi, web3xPath);
 }
 
-function getWeb3xPath() {
+export function getWeb3xPath() {
   const pkg = JSON.parse(fs.readFileSync(__dirname + '/../../package.json').toString());
   return pkg.name;
 }
@@ -510,4 +510,6 @@ async function main() {
   );
 }
 
-main().catch(console.error);
+if (require.main === module) {
+  main().catch(console.error);
+}


### PR DESCRIPTION
This is a small PR that exposes `codegen` as a library. 

It's mostly not running it unconditionally, and exporting a few functions. Apart from that, there's only one real change, which is in the first commit.