### PR TITLE
Ensure Contract.link replaces all instance references, not just one.

### DIFF
--- a/src/contract/contract.ts
+++ b/src/contract/contract.ts
@@ -88,7 +88,7 @@ export class Contract<T extends ContractDefinition | void = void> {
     const linkedData = Object.entries(this.linkTable).reduce(
       (data, [name, address]) =>
         data.replace(
-          new RegExp(`_+${name}_+`, 'i'),
+          new RegExp(`_+${name}_+`, 'gi'),
           address
             .toString()
             .slice(2)


### PR DESCRIPTION
Essentially if I use a contract that needs linked more than once inside a contract the current code won't replace all of the instances.  This fixes that.