### PR TITLE
Add optional gas parameter in ContractEntryDefinition

### DIFF
--- a/web3x/src/contract/abi/contract-abi-definition.ts
+++ b/web3x/src/contract/abi/contract-abi-definition.ts
@@ -29,6 +29,7 @@ export interface ContractEntryDefinition {
   type: 'function' | 'constructor' | 'event' | 'fallback';
   stateMutability?: 'pure' | 'view' | 'payable' | 'nonpayable';
   signature?: string;
+  gas?: number;
 }
 
 export type ContractAbiDefinition = ContractEntryDefinition[];


### PR DESCRIPTION
As stated in #55, `ContractEntryDefinition` looks like it lacks an optional gas parameter.