### PR TITLE
Add optional field `internalType` in AbiInput and AbiOutput to contract abi definition

### DIFF
--- a/web3x/src/contract/abi/contract-abi-definition.ts
+++ b/web3x/src/contract/abi/contract-abi-definition.ts
@@ -16,8 +16,19 @@
 */
 
 export type AbiDataTypes = 'uint256' | 'boolean' | 'string' | 'bytes' | string;
-export type AbiInput = { components?: any; name: string; type: AbiDataTypes; indexed?: boolean };
-export type AbiOutput = { components?: any; name: string; type: AbiDataTypes };
+export type AbiInput = {
+  components?: any;
+  name: string;
+  type: AbiDataTypes;
+  indexed?: boolean;
+  internalType?: string;
+};
+export type AbiOutput = {
+  components?: any;
+  name: string;
+  type: AbiDataTypes;
+  internalType?: string;
+};
 
 export interface ContractEntryDefinition {
   constant?: boolean;


### PR DESCRIPTION
Solidity compiler at version 0.5.11 added a yet undocumented ([except in changelog](https://github.com/ethereum/solidity/blob/develop/Changelog.md#0511-2019-08-12)) `internalType` field in the abi inputs/outputs.