### PR TITLE
Update ContractEntryDefinition with receive type

### DIFF
--- a/web3x/src/contract/abi/contract-abi-definition.ts
+++ b/web3x/src/contract/abi/contract-abi-definition.ts
@@ -37,7 +37,7 @@ export interface ContractEntryDefinition {
   inputs?: AbiInput[];
   name?: string;
   outputs?: AbiOutput[];
-  type: 'function' | 'constructor' | 'event' | 'fallback';
+  type: 'function' | 'constructor' | 'event' | 'fallback' | 'receive';
   stateMutability?: 'pure' | 'view' | 'payable' | 'nonpayable';
   signature?: string;
   gas?: number;


### PR DESCRIPTION
The latest Solidity release (^0.6.0) has an additional function type called receive. The type for ContractEntryDefinition in web3x-codegen does not include this function type, which breaks compatibility with Solidity versions above 0.6.0. This PR adds 'receive' to the type union for that field.