### PR TITLE
fix: send() to use result attr from response.

### DIFF
--- a/web3x/src/eth/eth.ts
+++ b/web3x/src/eth/eth.ts
@@ -72,7 +72,11 @@ export class Eth {
   }
 
   private async send<T>({ method, params, format }: { method: string; params?: any[]; format: (x: any) => T }) {
-    return format(await this.provider.send(method, params));
+    let ret = await this.provider.send(method, params);
+    if (typeof ret === 'object') {
+      ret = ret.result;
+    }
+    return format(ret);
   }
 
   public async getId() {


### PR DESCRIPTION
- Uses result attribute from returned json RPC response . => {"jsonrpc":"2.0","result":"0xfdd8813d61db00"}